### PR TITLE
Fix Platform Dependancy on Linux

### DIFF
--- a/emulator/requirements.txt
+++ b/emulator/requirements.txt
@@ -21,7 +21,7 @@ overload~=1.1
 asyncio~=3.4.3
 creditcard~=1.0.2
 ping3~=4.0.8
-pywin32;sys.platform='win32'
+pywin32;sys.platform=='win32'
 blessed~=1.20.0
 pillow~=10.3.0
 Levenshtein~=0.25.1

--- a/emulator/requirements.txt
+++ b/emulator/requirements.txt
@@ -21,7 +21,7 @@ overload~=1.1
 asyncio~=3.4.3
 creditcard~=1.0.2
 ping3~=4.0.8
-pywin32
+pywin32;sys.platform='win32'
 blessed~=1.20.0
 pillow~=10.3.0
 Levenshtein~=0.25.1


### PR DESCRIPTION
This simply checks if the platform is win32, if so it will install pywin32 else it will be ignored on pip installation.