### PR TITLE
fix(sendmail): fix email delivery and broken links for external SMTP Providers

### DIFF
--- a/emulator/servers/authserver.py
+++ b/emulator/servers/authserver.py
@@ -524,8 +524,12 @@ class authserver(TCPNetworkHandler):
         
         # TODO CHECK VERIFICATION CODE FOR TIME (less than 15 minutes old) AND AGAINST WHAT THE USER SENT AS THE CODE
 
-        #if self.validationcode_manager.validate_code(code, username): # DONT CARE ABOUT THIS YET
-        self.database.set_email_verified(username)
+        if self.database.check_validationcode(username, verification_code_from_client): # FORCE THE EMULATOR TO CHECK THE VALIDATION CODE ON THE DATABASE!
+            self.database.set_email_verified(username)
+        else:
+            self.log.warning(f"{clientid}Email verification code invalid or expired for: {username}")
+            client_socket.send(b"\x01")
+            return
 
         if globalvars.steamui_ver == 20:
             pkt_version = "b2004"

--- a/emulator/servers/authserver.py
+++ b/emulator/servers/authserver.py
@@ -524,12 +524,8 @@ class authserver(TCPNetworkHandler):
         
         # TODO CHECK VERIFICATION CODE FOR TIME (less than 15 minutes old) AND AGAINST WHAT THE USER SENT AS THE CODE
 
-        if self.database.check_validationcode(username, verification_code_from_client): # FORCE THE EMULATOR TO CHECK THE VALIDATION CODE ON THE DATABASE!
-            self.database.set_email_verified(username)
-        else:
-            self.log.warning(f"{clientid}Email verification code invalid or expired for: {username}")
-            client_socket.send(b"\x01")
-            return
+        #if self.validationcode_manager.validate_code(code, username): # DONT CARE ABOUT THIS YET
+        self.database.set_email_verified(username)
 
         if globalvars.steamui_ver == 20:
             pkt_version = "b2004"

--- a/emulator/utilities/sendmail.py
+++ b/emulator/utilities/sendmail.py
@@ -70,7 +70,7 @@ def load_email_template(template_name, **kwargs):
     if http_ip:
         kwargs['network_url'] = http_ip
     elif http_domainname:
-        kwargs['network_url'] = f"http://{http_domainname}"
+        kwargs['network_url'] = f"{http_domainname}"
     else:
         kwargs['network_url'] = ''
         print("WARNING: Neither 'http_ip' nor 'http_domainname' configured — email links will be broken!")

--- a/emulator/utilities/sendmail.py
+++ b/emulator/utilities/sendmail.py
@@ -49,7 +49,7 @@ def send_templated_email(to_email, subject, template_name, **kwargs):
     body = load_email_template(template_name, **kwargs)
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
     part = MIMEText(body, 'html')
     msg.attach(part)
@@ -63,8 +63,17 @@ def load_email_template(template_name, **kwargs):
 
     kwargs['support_email'] = config['support_email']
     kwargs['network_name'] = config['network_name']
-    kwargs['network_url'] = config['http_ip']
     kwargs['logo_url'] = config['network_logo']
+
+    http_ip = config.get('http_ip', '').strip()
+    http_domainname = config.get('http_domainname', '').strip()
+    if http_ip:
+        kwargs['network_url'] = http_ip
+    elif http_domainname:
+        kwargs['network_url'] = f"http://{http_domainname}"
+    else:
+        kwargs['network_url'] = ''
+        print("WARNING: Neither 'http_ip' nor 'http_domainname' configured — email links will be broken!")
 
     if config['email_location_support'].lower() == "true":
         country, region_name = utils.get_location(kwargs['ipaddress'])
@@ -82,7 +91,7 @@ def send_username_email(to_email, username, ipaddress):
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     # Attach the HTML version of the body
@@ -98,7 +107,7 @@ def send_reset_password_email(to_email, verification_code, question, ipaddress, 
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     # Attach the HTML version of the body
@@ -138,7 +147,7 @@ def send_password_changed_email(to_email, ipaddress, username):
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     # Attach the HTML version of the body
@@ -153,7 +162,7 @@ def send_attempted_pw_change_email(to_email, ipaddress, username):
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     # Attach the HTML version of the body
@@ -168,7 +177,7 @@ def send_question_changed_confirmation(to_email, ipaddress, username):
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     # Attach the HTML version of the body
@@ -183,7 +192,7 @@ def send_email_changed_email(to_email, ipaddress, username):
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     # Attach the HTML version of the body
@@ -199,7 +208,7 @@ def send_friends_invite_email(to_email, ipaddress, username):
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     # Attach the HTML version of the body
@@ -214,7 +223,7 @@ def send_validation_code_email(to_email, verification_token, ipaddress, username
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     # Attach the HTML version of the body
@@ -265,7 +274,7 @@ def send_purchase_receipt_email(to_email, username, items, subtotal, tax, total,
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     part = MIMEText(body, 'html')
@@ -315,7 +324,7 @@ def send_gift_purchase_receipt_email(to_email, username, items, subtotal, tax, t
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     part = MIMEText(body, 'html')
@@ -343,7 +352,7 @@ def send_new_computer_access_email(to_email, username, access_code):
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     part = MIMEText(body, 'html')
@@ -403,7 +412,7 @@ def send_wishlist_sale_email(to_email, username, wishlist_items, unsubscribe_url
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     part = MIMEText(body, 'html')
@@ -457,7 +466,7 @@ def send_gift_received_email(to_email, recipient_email, sender_username, sender_
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     part = MIMEText(body, 'html')
@@ -487,7 +496,7 @@ def send_forgotten_password_email(to_email, username, verification_code):
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     part = MIMEText(body, 'html')
@@ -515,7 +524,7 @@ def send_query_account_by_email(to_email, username):
 
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
-    msg['From'] = config['smtp_username']
+    msg['From'] = f"{config['network_name']} <{config['support_email']}>"
     msg['To'] = to_email
 
     part = MIMEText(body, 'html')


### PR DESCRIPTION
The original code used smtp_username as the From address, which breaks delivery with providers like Resend, so i updated all functions to use support_email with a display name as the From header, keeping smtp_username only for SMTP authentication. This also includes a fix for email links being broken when http_ip is not set (example: "http:///verify.php"). 
When neither is configured, a warning is printed so the issue is easy to spot. 
Also, there was a minor typo in load_email_template, where ip_location_ip was used instead of ip_location_msg, which could cause a KeyError in the templates.