### PR TITLE
fix(cser): add survey protocol v1 support and fix survey recording pipeline

### DIFF
--- a/emulator/servers/authserver.py
+++ b/emulator/servers/authserver.py
@@ -523,13 +523,8 @@ class authserver(TCPNetworkHandler):
         verification_code_from_client = blob[:-struct.unpack(">B", blob[-1:])[0]].decode('latin-1')
         
         # TODO CHECK VERIFICATION CODE FOR TIME (less than 15 minutes old) AND AGAINST WHAT THE USER SENT AS THE CODE
-
-        if self.database.check_validationcode(username, verification_code_from_client): # FORCE THE EMULATOR TO CHECK THE VALIDATION CODE ON THE DATABASE!
-            self.database.set_email_verified(username)
-        else:
-            self.log.warning(f"{clientid}Email verification code invalid or expired for: {username}")
-            client_socket.send(b"\x01")
-            return
+        #if self.validationcode_manager.validate_code(code, username): # DONT CARE ABOUT THIS YET
+        self.database.set_email_verified(username)
 
         if globalvars.steamui_ver == 20:
             pkt_version = "b2004"

--- a/emulator/servers/authserver.py
+++ b/emulator/servers/authserver.py
@@ -524,8 +524,12 @@ class authserver(TCPNetworkHandler):
         
         # TODO CHECK VERIFICATION CODE FOR TIME (less than 15 minutes old) AND AGAINST WHAT THE USER SENT AS THE CODE
 
-        #if self.validationcode_manager.validate_code(code, username): # DONT CARE ABOUT THIS YET
-        self.database.set_email_verified(username)
+        if self.database.check_validationcode(username, verification_code_from_client): # FORCE THE EMULATOR TO CHECK THE VALIDATION CODE ON THE DATABASE!
+            self.database.set_email_verified(username)
+        else:
+            self.log.warning(f"{clientid}Email verification code invalid or expired for: {username}")
+            client_socket.send(b"\x01")
+            return
 
         if globalvars.steamui_ver == 20:
             pkt_version = "b2004"

--- a/emulator/servers/cserserver.py
+++ b/emulator/servers/cserserver.py
@@ -803,9 +803,9 @@ class CSERServer(UDPNetworkHandler):
         ack_payload = reply_header + b"\x01" + struct.pack("<I", session_id)
 
         self.serversocket.sendto(ack_payload, address)
-
+        
     def parse_surveyresults(self, address, data, clientid):
-        self.log.info(f'{clientid}Received Survey Results')
+        self.log.info(f'{clientid}Recieved Survey Results')
 
         ice = IceKey(1, [27, 200, 13, 14, 83, 45, 184, 54])
         data_bin = bytes.fromhex(data[3:].hex())
@@ -1060,6 +1060,34 @@ class CSERServer(UDPNetworkHandler):
                     index += 4
                 result['drives'] = drives
 
+            elif data[0:1] == b"\x01":
+                result['clientid'], index = self.read_string(byte_string, index)
+                result['ramsize'], index = struct.unpack('<I', byte_string[index:index + 4])[0], index + 4
+                result['processorspeed'], index = struct.unpack('<I', byte_string[index:index + 4])[0], index + 4
+                result['netspeed'], index = struct.unpack('<I', byte_string[index:index + 4])[0], index + 4
+                result['screensize'], index = struct.unpack('<I', byte_string[index:index + 4])[0], index + 4
+                result['rendermode'], index = byte_string[index], index + 1
+                result['bitdepth'], index = struct.unpack('B', byte_string[index:index + 1])[0], index + 1
+                index += 1
+                result['videodriverdll'], index = self.read_string(byte_string, index)
+                index += 1
+                result['videocard'], index = self.read_string(byte_string, index)
+                result['highvidcardver'], index = struct.unpack('<I', byte_string[index:index + 4])[0], index + 4
+                result['lowvidcardver'], index = struct.unpack('<I', byte_string[index:index + 4])[0], index + 4
+                result['cardvendorid'], index = struct.unpack('<I', byte_string[index:index + 4])[0], index + 4
+                result['deviceid'], index = struct.unpack('<I', byte_string[index:index + 4])[0], index + 4
+                for field in ['rdtsc', 'cmov', 'fcmov', 'sse', 'sse2', '3dnow', 'ntfs']:
+                    result[field], index = byte_string[index], index + 1
+                result['proctype'], index = self.read_string(byte_string, index)
+                result['logicalprocessorcount'], index = byte_string[index], index + 1
+                result['physicalproccesorcount'], index = byte_string[index], index + 1
+                result['hyperthreading'], index = byte_string[index], index + 1
+                result['winver'], index = self.read_string(byte_string, index)
+                ip_parts = struct.unpack('BBB', byte_string[index:index + 3])
+                result['ipaddress'], index = "{}.{}.{}.xxx".format(*ip_parts), index + 3
+                result['languageid'], index = byte_string[index], index + 1
+
             statistics_db.record_s3surveydata(result)
+            statistics_db.record_survey(result)
 
             self.serversocket.sendto(b"\xFF\xFF\xFF\xFF\x68\x01\x00\x00\x00" + b"thank you\x00", address)

--- a/emulator/utilities/database/statistics_db.py
+++ b/emulator/utilities/database/statistics_db.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from datetime import datetime, date
-from sqlalchemy import func
+from sqlalchemy import func, text
 from sqlalchemy.exc import IntegrityError
 
 import globalvars
@@ -82,29 +82,27 @@ class base_stats_dbdriver:
             return False
 
     def record_survey(self, results):
-        # store survey results and update aggregated totals
+        # store survey results and update aggregated totals atomically
         try:
             raw = self.SurveyRaw(
                 ts=datetime.utcnow(),
                 data=json.dumps(results, default=_json_default),
             )
             self.session.add(raw)
+            self.session.flush()
 
             for field, value in results.items():
                 if field == 'DecryptionOK':
                     continue
                 val = str(value)
-                tot = (
-                    self.session
-                        .query(self.SurveyTotals)
-                        .filter_by(field=field, option_value=val)
-                        .first()
+                self.session.execute(
+                    text(
+                        "INSERT INTO survey_totals (field, option_value, count) "
+                        "VALUES (:field, :option_value, 1) "
+                        "ON DUPLICATE KEY UPDATE count = count + 1"
+                    ),
+                    {"field": field, "option_value": val}
                 )
-                if tot:
-                    tot.count += 1
-                else:
-                    tot = self.SurveyTotals(field=field, option_value=val, count=1)
-                    self.session.add(tot)
 
             self.session.commit()
             return True
@@ -281,4 +279,3 @@ def _get_driver():
 def __getattr__(name):
     """Delegate attribute access to the underlying driver instance."""
     return getattr(_get_driver(), name)
-


### PR DESCRIPTION
Implemented a Handler for the Protocol version 0x01, this protocol is used on the First Steam Survey.

**record_survey()** is now called after **record_s3surveydata()** so results are aggregated into survey_totals.

This PR also fixes two issues that prevented survey recording from working at all:
- Added missing __init__.py to utilities/database, which caused an ImportError
  when importing statistics_db
- fixed a race condition in record_survey() by replacing the
SELECT + INSERT/UPDATE pattern with a single atomic
INSERT ... ON DUPLICATE KEY UPDATE, eliminating MariaDB error 1020.
